### PR TITLE
annotate class vars of default Server class for autocompletion reasons

### DIFF
--- a/src/OAuth2Provider/Server.php
+++ b/src/OAuth2Provider/Server.php
@@ -2,16 +2,29 @@
 namespace OAuth2Provider;
 
 use Zend\ServiceManager;
-
 use OAuth2\Server as OAuth2Server;
-
 use ReflectionClass;
 
 class Server implements ServiceManager\ServiceManagerAwareInterface, ServerInterface
 {
+    /**
+     * @var \OAuth2\Server
+     */
     protected $server;
+
+    /**
+     * @var ServiceManager\ServiceManager
+     */
     protected $serviceManager;
+
+    /**
+     * @var \OAuth2\Request
+     */
     protected $request;
+
+    /**
+     * @var \OAuth2\Response
+     */
     protected $response;
 
     /**


### PR DESCRIPTION
In this case annotated class vars enables an IDE to autocomplete requests to default Server class.
